### PR TITLE
Fixing subsection links

### DIFF
--- a/public/_index.html
+++ b/public/_index.html
@@ -185,7 +185,7 @@
 
   <hr />
 
-  <h2>Neural Turing Machines</h2>
+  <h2 id="neural-turing-machines">Neural Turing Machines</h2>
 
   <p>Neural Turing Machines <dt-cite key="graves2014neural"></dt-cite> combine a RNN with an external memory bank. Since vectors are the natural language of neural networks, the memory is an array of vectors:</p>
 
@@ -236,7 +236,7 @@
 
   <hr />
 
-  <h2>Attentional Interfaces</h2>
+  <h2 id="attentional-interfaces">Attentional Interfaces</h2>
 
   <p>When I’m translating a sentence, I pay special attention to the word I’m presently translating. When I’m transcribing an audio recording, I listen carefully to the segment I’m actively writing down. And if you ask me to describe the room I’m sitting in, I’ll glance around at the objects I’m describing as I do so.</p>
 
@@ -277,7 +277,7 @@
 
   <hr />
 
-  <h2>Adaptive Computation Time</h2>
+  <h2 id="adaptive-computation-time">Adaptive Computation Time</h2>
 
   <p class="equation-mimic">Standard RNNs do the same amount of computation each time step. This seems unintuitive. Surely, one should think more when things are hard? It also limits RNNs to doing <span class="equation-mimic">O(n)</span> operations for a list of length <span class="equation-mimic">n</span>.</p>
 
@@ -329,7 +329,7 @@
 
   <hr />
 
-  <h2>Neural Programmer</h2>
+  <h2 id="neural-programmer">Neural Programmer</h2>
 
   <p>Neural nets are excellent at many tasks, but they also struggle to do some basic things like arithmetic, which are trivial in normal approaches to computing. It would be really nice to have a way to fuse neural nets with normal programming, and get the best of both worlds.</p>
 


### PR DESCRIPTION
The section links (e.g. pointing to the section on "Neural Turing Machines") in don't have matching target sections. 

This pull request just adds `id` attributes to the target section titles.