### PR TITLE
Fix links into tensorflow/models

### DIFF
--- a/public/_index.html
+++ b/public/_index.html
@@ -232,7 +232,7 @@
 
   <h3>Code</h3>
 
-  <p>There are a number of open source implementations of these models. Open source implementations of the Neural Turing Machine include <a href="https://github.com/carpedm20/NTM-tensorflow">Taehoon Kim's</a> (TensorFlow), <a href="https://github.com/shawntan/neural-turing-machines">Shawn Tan's</a> (Theano), <a href="https://github.com/fumin/ntm">Fumin's</a> (Go), <a href="https://github.com/kaishengtai/torch-ntm">Kai Sheng Tai's</a> (Torch), and <a href="https://github.com/snipsco/ntm-lasagne">Snip's</a> (Lasagne). Code for the Neural GPU publication was open sourced and put in the <a href="https://github.com/tensorflow/models/tree/master/neural_gpu">TensorFlow Models repository</a>. Open source implementations of Memory Networks include <a href="https://github.com/facebook/MemNN">Facebook's</a> (Torch/Matlab), <a href="https://github.com/YerevaNN/Dynamic-memory-networks-in-Theano">YerevaNN's</a> (Theano), and <a href="https://github.com/carpedm20/MemN2N-tensorflow">Taehoon Kim's</a> (TensorFlow). </span></p></p>
+  <p>There are a number of open source implementations of these models. Open source implementations of the Neural Turing Machine include <a href="https://github.com/carpedm20/NTM-tensorflow">Taehoon Kim's</a> (TensorFlow), <a href="https://github.com/shawntan/neural-turing-machines">Shawn Tan's</a> (Theano), <a href="https://github.com/fumin/ntm">Fumin's</a> (Go), <a href="https://github.com/kaishengtai/torch-ntm">Kai Sheng Tai's</a> (Torch), and <a href="https://github.com/snipsco/ntm-lasagne">Snip's</a> (Lasagne). Code for the Neural GPU publication was open sourced and put in the <a href="https://github.com/tensorflow/models/tree/master/research/neural_gpu">TensorFlow Models repository</a>. Open source implementations of Memory Networks include <a href="https://github.com/facebook/MemNN">Facebook's</a> (Torch/Matlab), <a href="https://github.com/YerevaNN/Dynamic-memory-networks-in-Theano">YerevaNN's</a> (Theano), and <a href="https://github.com/carpedm20/MemN2N-tensorflow">Taehoon Kim's</a> (TensorFlow). </span></p></p>
 
   <hr />
 
@@ -370,7 +370,7 @@
 
   <h3>Code</h3>
 
-  <p>The more recent version of Neural Programmer for <a href="https://openreview.net/pdf?id=ry2YOrcge">question answering</a> has been open sourced by its authors and is available as a <a href="https://github.com/tensorflow/models/tree/master/neural_programmer">TensorFlow Model</a>. There is also an implementation of the Neural Programmer-Interpreter by <a href="https://github.com/mokemokechicken/keras_npi">Ken Morishita</a> (Keras).</p>
+  <p>The more recent version of Neural Programmer for <a href="https://openreview.net/pdf?id=ry2YOrcge">question answering</a> has been open sourced by its authors and is available as a <a href="https://github.com/tensorflow/models/tree/master/research/neural_programmer">TensorFlow Model</a>. There is also an implementation of the Neural Programmer-Interpreter by <a href="https://github.com/mokemokechicken/keras_npi">Ken Morishita</a> (Keras).</p>
 
   <hr />
 

--- a/public/index.html
+++ b/public/index.html
@@ -1693,7 +1693,7 @@ redraw();
 
   <h3>Code</h3>
 
-  <p>There are a number of open source implementations of these models. Open source implementations of the Neural Turing Machine include <a href="https://github.com/carpedm20/NTM-tensorflow">Taehoon Kim's</a> (TensorFlow), <a href="https://github.com/shawntan/neural-turing-machines">Shawn Tan's</a> (Theano), <a href="https://github.com/fumin/ntm">Fumin's</a> (Go), <a href="https://github.com/kaishengtai/torch-ntm">Kai Sheng Tai's</a> (Torch), and <a href="https://github.com/snipsco/ntm-lasagne">Snip's</a> (Lasagne). Code for the Neural GPU publication was open sourced and put in the <a href="https://github.com/tensorflow/models/tree/master/neural_gpu">TensorFlow Models repository</a>. Open source implementations of Memory Networks include <a href="https://github.com/facebook/MemNN">Facebook's</a> (Torch/Matlab), <a href="https://github.com/YerevaNN/Dynamic-memory-networks-in-Theano">YerevaNN's</a> (Theano), and <a href="https://github.com/carpedm20/MemN2N-tensorflow">Taehoon Kim's</a> (TensorFlow). </p><p></p>
+  <p>There are a number of open source implementations of these models. Open source implementations of the Neural Turing Machine include <a href="https://github.com/carpedm20/NTM-tensorflow">Taehoon Kim's</a> (TensorFlow), <a href="https://github.com/shawntan/neural-turing-machines">Shawn Tan's</a> (Theano), <a href="https://github.com/fumin/ntm">Fumin's</a> (Go), <a href="https://github.com/kaishengtai/torch-ntm">Kai Sheng Tai's</a> (Torch), and <a href="https://github.com/snipsco/ntm-lasagne">Snip's</a> (Lasagne). Code for the Neural GPU publication was open sourced and put in the <a href="https://github.com/tensorflow/models/tree/master/research/neural_gpu">TensorFlow Models repository</a>. Open source implementations of Memory Networks include <a href="https://github.com/facebook/MemNN">Facebook's</a> (Torch/Matlab), <a href="https://github.com/YerevaNN/Dynamic-memory-networks-in-Theano">YerevaNN's</a> (Theano), and <a href="https://github.com/carpedm20/MemN2N-tensorflow">Taehoon Kim's</a> (TensorFlow). </p><p></p>
 
   <hr>
 
@@ -5232,7 +5232,7 @@ audio.selectAll(".segment")
 
   <h3>Code</h3>
 
-  <p>The more recent version of Neural Programmer for <a href="https://openreview.net/pdf?id=ry2YOrcge">question answering</a> has been open sourced by its authors and is available as a <a href="https://github.com/tensorflow/models/tree/master/neural_programmer">TensorFlow Model</a>. There is also an implementation of the Neural Programmer-Interpreter by <a href="https://github.com/mokemokechicken/keras_npi">Ken Morishita</a> (Keras).</p>
+  <p>The more recent version of Neural Programmer for <a href="https://openreview.net/pdf?id=ry2YOrcge">question answering</a> has been open sourced by its authors and is available as a <a href="https://github.com/tensorflow/models/tree/master/research/neural_programmer">TensorFlow Model</a>. There is also an implementation of the Neural Programmer-Interpreter by <a href="https://github.com/mokemokechicken/keras_npi">Ken Morishita</a> (Keras).</p>
 
   <hr>
 


### PR DESCRIPTION
These were broken by <https://github.com/tensorflow/models/pull/2430>.

wchargin-branch: tf-models-links